### PR TITLE
Add sliders and dropdown for settings

### DIFF
--- a/src/parametre.cpp
+++ b/src/parametre.cpp
@@ -21,26 +21,47 @@ static void renderOption(SDL_Renderer* renderer, TTF_Font* font,
     }
 }
 
+static void renderSliderOption(SDL_Renderer* renderer, TTF_Font* font,
+                               const std::string& label,
+                               const std::vector<std::string>& options,
+                               int index, int x, int y, bool selected) {
+    std::string line = label + ": ";
+    for (size_t i = 0; i < options.size(); ++i) {
+        if (i == static_cast<size_t>(index))
+            line += "[" + options[i] + "]";
+        else
+            line += options[i];
+        if (i + 1 < options.size()) line += " | ";
+    }
+    renderOption(renderer, font, line, x, y, selected);
+}
+
 void showSettings(SDL_Window* window, SDL_Renderer* renderer,
                   int &width, int &height, int &fps, std::string &language) {
-    std::vector<std::string> languages = {"Francais", "English", "Español"};
+    std::vector<std::string> languages = {"Francais", "English"};
     int langIndex = 0;
     for (size_t i = 0; i < languages.size(); ++i)
         if (languages[i] == language) langIndex = static_cast<int>(i);
 
-    std::vector<SDL_Point> sizes = {{800,600},{1024,768},{1280,720}};
+    std::vector<SDL_Point> sizes = {{800,450},{1280,720},{1920,1080}};
+    std::vector<std::string> sizeLabels;
+    for (const auto& s : sizes)
+        sizeLabels.push_back(std::to_string(s.x) + "x" + std::to_string(s.y));
     int sizeIndex = 0;
     for (size_t i = 0; i < sizes.size(); ++i)
         if (sizes[i].x == width && sizes[i].y == height)
             sizeIndex = static_cast<int>(i);
 
     std::vector<int> fpsOptions = {30, 60, 120};
+    std::vector<std::string> fpsLabels;
+    for (int f : fpsOptions) fpsLabels.push_back(std::to_string(f));
     int fpsIndex = 1; // default 60
     for (size_t i = 0; i < fpsOptions.size(); ++i)
         if (fpsOptions[i] == fps) fpsIndex = static_cast<int>(i);
 
     enum Option { LANG, SIZE, FPS, COUNT };
     int current = 0;
+    bool langMenu = false;
 
     std::string fontPath = "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf";
     TTF_Font* font = TTF_OpenFont(fontPath.c_str(), 24);
@@ -58,29 +79,46 @@ void showSettings(SDL_Window* window, SDL_Renderer* renderer,
             else if (e.type == SDL_KEYDOWN) {
                 switch (e.key.keysym.sym) {
                     case SDLK_ESCAPE:
-                        running = false;
+                        if (langMenu)
+                            langMenu = false;
+                        else
+                            running = false;
+                        break;
+                    case SDLK_RETURN:
+                        if (current == LANG)
+                            langMenu = !langMenu;
                         break;
                     case SDLK_UP:
-                        current = (current + COUNT - 1) % COUNT;
+                        if (langMenu)
+                            langIndex = (langIndex + languages.size() - 1) % languages.size();
+                        else
+                            current = (current + COUNT - 1) % COUNT;
                         break;
                     case SDLK_DOWN:
-                        current = (current + 1) % COUNT;
+                        if (langMenu)
+                            langIndex = (langIndex + 1) % languages.size();
+                        else
+                            current = (current + 1) % COUNT;
                         break;
                     case SDLK_LEFT:
-                        if (current == LANG)
-                            langIndex = (langIndex + languages.size() - 1) % languages.size();
-                        else if (current == SIZE)
-                            sizeIndex = (sizeIndex + sizes.size() - 1) % sizes.size();
-                        else if (current == FPS)
-                            fpsIndex = (fpsIndex + fpsOptions.size() - 1) % fpsOptions.size();
+                        if (!langMenu) {
+                            if (current == LANG)
+                                langIndex = (langIndex + languages.size() - 1) % languages.size();
+                            else if (current == SIZE)
+                                sizeIndex = (sizeIndex + sizes.size() - 1) % sizes.size();
+                            else if (current == FPS)
+                                fpsIndex = (fpsIndex + fpsOptions.size() - 1) % fpsOptions.size();
+                        }
                         break;
                     case SDLK_RIGHT:
-                        if (current == LANG)
-                            langIndex = (langIndex + 1) % languages.size();
-                        else if (current == SIZE)
-                            sizeIndex = (sizeIndex + 1) % sizes.size();
-                        else if (current == FPS)
-                            fpsIndex = (fpsIndex + 1) % fpsOptions.size();
+                        if (!langMenu) {
+                            if (current == LANG)
+                                langIndex = (langIndex + 1) % languages.size();
+                            else if (current == SIZE)
+                                sizeIndex = (sizeIndex + 1) % sizes.size();
+                            else if (current == FPS)
+                                fpsIndex = (fpsIndex + 1) % fpsOptions.size();
+                        }
                         break;
                 }
             }
@@ -89,14 +127,29 @@ void showSettings(SDL_Window* window, SDL_Renderer* renderer,
         SDL_SetRenderDrawColor(renderer, 30, 30, 30, 255);
         SDL_RenderClear(renderer);
 
-        renderOption(renderer, font, "Langue: " + languages[langIndex], 50, 80, current == LANG);
-        renderOption(renderer, font,
-                     "Taille fenetre: " + std::to_string(sizes[sizeIndex].x) + "x" +
-                         std::to_string(sizes[sizeIndex].y),
-                     50, 140, current == SIZE);
-        renderOption(renderer, font, "FPS: " + std::to_string(fpsOptions[fpsIndex]),
-                     50, 200, current == FPS);
-        renderOption(renderer, font, "Esc pour retourner", 50, 260, false);
+        if (!langMenu) {
+            renderOption(renderer, font,
+                         "Langue: " + languages[langIndex] + " v", 50, 80,
+                         current == LANG);
+            renderSliderOption(renderer, font, "Taille fenetre", sizeLabels,
+                               sizeIndex, 50, 140, current == SIZE);
+            renderSliderOption(renderer, font, "FPS", fpsLabels,
+                               fpsIndex, 50, 200, current == FPS);
+            renderOption(renderer, font, "Esc pour retourner", 50, 260, false);
+        } else {
+            renderOption(renderer, font, "Langue v", 50, 80, current == LANG);
+            for (size_t i = 0; i < languages.size(); ++i)
+                renderOption(renderer, font, "  " + languages[i], 70, 120 + static_cast<int>(i)*40,
+                             i == static_cast<size_t>(langIndex));
+            int base = 120 + static_cast<int>(languages.size()) * 40 + 40;
+            renderSliderOption(renderer, font, "Taille fenetre", sizeLabels,
+                               sizeIndex, 50, base, current == SIZE);
+            base += 60;
+            renderSliderOption(renderer, font, "FPS", fpsLabels,
+                               fpsIndex, 50, base, current == FPS);
+            base += 60;
+            renderOption(renderer, font, "Esc pour retourner", 50, base, false);
+        }
 
         SDL_RenderPresent(renderer);
     }


### PR DESCRIPTION
## Summary
- implement slider rendering helper
- overhaul `showSettings` to use sliders for FPS and window size
- switch language option to a dropdown menu with French/English
- update supported resolutions to common 16:9 sizes

## Testing
- `make`

------
https://chatgpt.com/codex/tasks/task_e_685722ae4a6c83219aa30516390b13f2