### PR TITLE
Add mouse support for settings menu

### DIFF
--- a/src/ui_helpers.cpp
+++ b/src/ui_helpers.cpp
@@ -1,0 +1,42 @@
+#include "ui_helpers.h"
+#include <iostream>
+
+bool pointInRect(int x, int y, const SDL_Rect& r) {
+    return x >= r.x && x <= r.x + r.w && y >= r.y && y <= r.y + r.h;
+}
+
+void renderOption(SDL_Renderer* renderer, TTF_Font* font,
+                  const std::string& text, int x, int y, bool selected,
+                  SDL_Rect* outRect) {
+    SDL_Color color = selected ? SDL_Color{255, 255, 0, 255}
+                               : SDL_Color{255, 255, 255, 255};
+    SDL_Surface* surf = TTF_RenderUTF8_Blended(font, text.c_str(), color);
+    if (!surf) {
+        std::cerr << "Failed to create surface: " << TTF_GetError() << std::endl;
+        return;
+    }
+    SDL_Texture* tex = SDL_CreateTextureFromSurface(renderer, surf);
+    SDL_Rect dst{x, y, surf->w, surf->h};
+    if (outRect) *outRect = dst;
+    SDL_FreeSurface(surf);
+    if (tex) {
+        SDL_RenderCopy(renderer, tex, nullptr, &dst);
+        SDL_DestroyTexture(tex);
+    }
+}
+
+void renderSliderOption(SDL_Renderer* renderer, TTF_Font* font,
+                        const std::string& label,
+                        const std::vector<std::string>& options,
+                        int index, int x, int y, bool selected,
+                        SDL_Rect* outRect) {
+    std::string line = label + ": ";
+    for (size_t i = 0; i < options.size(); ++i) {
+        if (i == static_cast<size_t>(index))
+            line += "[" + options[i] + "]";
+        else
+            line += options[i];
+        if (i + 1 < options.size()) line += " | ";
+    }
+    renderOption(renderer, font, line, x, y, selected, outRect);
+}

--- a/src/ui_helpers.h
+++ b/src/ui_helpers.h
@@ -1,0 +1,21 @@
+#ifndef UI_HELPERS_H
+#define UI_HELPERS_H
+
+#include <SDL2/SDL.h>
+#include <SDL2/SDL_ttf.h>
+#include <string>
+#include <vector>
+
+bool pointInRect(int x, int y, const SDL_Rect& r);
+
+void renderOption(SDL_Renderer* renderer, TTF_Font* font,
+                  const std::string& text, int x, int y, bool selected,
+                  SDL_Rect* outRect = nullptr);
+
+void renderSliderOption(SDL_Renderer* renderer, TTF_Font* font,
+                        const std::string& label,
+                        const std::vector<std::string>& options,
+                        int index, int x, int y, bool selected,
+                        SDL_Rect* outRect = nullptr);
+
+#endif // UI_HELPERS_H


### PR DESCRIPTION
## Summary
- allow detection of mouse clicks in `showSettings`
- compute clickable areas for language, window size and FPS entries
- expose helper to test whether a point is inside a rectangle
- split helpers to dedicated `ui_helpers` files

## Testing
- `make`
- `./jeuuuuu` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_6857264071008321a624f97da11cee58