### PR TITLE
Add GameAI integration example

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,28 @@ scripts/      - helper scripts
 src/          - source files
 ```
 
+## AI Integration
+
+The project includes a `GameAI` helper that invokes `scripts/ai_prompt.py` to
+generate text using a local TinyLlama model.
+
+1. Install the Python bindings:
+
+   ```sh
+   pip install llama-cpp-python
+   ```
+
+   Or build `llama.cpp` manually:
+
+   ```sh
+   git clone https://github.com/ggerganov/llama.cpp
+   cd llama.cpp && make
+   ```
+
+2. Place the `TinyLlama.Q4_0.gguf` model in the `models/` directory.
+
+The game calls the script at runtime to obtain generated text.
+
 ## Contributing
 
 See [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/models/TinyLlama.Q4_0.gguf
+++ b/models/TinyLlama.Q4_0.gguf
@@ -1,0 +1,1 @@
+Placeholder model file

--- a/scripts/ai_prompt.py
+++ b/scripts/ai_prompt.py
@@ -1,0 +1,29 @@
+#!/usr/bin/env python3
+"""Query TinyLlama model using llama-cpp-python."""
+
+import sys
+from pathlib import Path
+
+MODEL_PATH = Path(__file__).resolve().parent.parent / "models" / "TinyLlama.Q4_0.gguf"
+
+
+def main() -> int:
+    prompt = " ".join(sys.argv[1:]) if len(sys.argv) > 1 else sys.stdin.read()
+    try:
+        from llama_cpp import Llama
+    except Exception as exc:
+        sys.stderr.write(f"Failed to import llama_cpp: {exc}\n")
+        return 1
+
+    try:
+        llm = Llama(model_path=str(MODEL_PATH), n_ctx=512)
+        output = llm(prompt, max_tokens=128)
+        print(output["choices"][0]["text"].strip())
+    except Exception as exc:
+        sys.stderr.write(f"LLM error: {exc}\n")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ set(SOURCES
     menu.cpp
     monstre.cpp
     objet.cpp
+    GameAI.cpp
     parametre.cpp
     personage.cpp
     ui_helpers.cpp

--- a/src/GameAI.cpp
+++ b/src/GameAI.cpp
@@ -1,0 +1,38 @@
+#include "GameAI.h"
+
+#include <array>
+#include <cstdio>
+#include <string>
+
+namespace {
+std::string escapeQuotes(const std::string &in) {
+    std::string out;
+    out.reserve(in.size());
+    for (char c : in) {
+        if (c == '"') out += '\\';
+        out += c;
+    }
+    return out;
+}
+}
+
+GameAI::GameAI(const std::string &script) : scriptPath(script) {}
+
+std::string GameAI::generateObject(const std::string &prompt) {
+    std::string cmd = "python3 \"" + scriptPath + "\" \"" + escapeQuotes(prompt) + "\"";
+
+    std::array<char, 128> buffer{};
+    std::string result;
+    FILE *pipe = popen(cmd.c_str(), "r");
+    if (!pipe)
+        return "Error: cannot run Python script";
+    while (fgets(buffer.data(), buffer.size(), pipe)) {
+        result += buffer.data();
+    }
+    int rc = pclose(pipe);
+    if (rc != 0)
+        return "Error: Python script failed";
+    if (!result.empty() && result.back() == '\n')
+        result.pop_back();
+    return result;
+}

--- a/src/GameAI.h
+++ b/src/GameAI.h
@@ -1,0 +1,19 @@
+#ifndef GAMEAI_H
+#define GAMEAI_H
+
+#include <string>
+
+/**
+ * @brief Wrapper class to request text generation from a Python script running
+ * TinyLlama.
+ */
+class GameAI {
+public:
+    explicit GameAI(const std::string &script = "../scripts/ai_prompt.py");
+    std::string generateObject(const std::string &prompt);
+
+private:
+    std::string scriptPath;
+};
+
+#endif // GAMEAI_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 #include <iostream>
 #include <string>
 #include "menu.h"
+#include "GameAI.h"
 
 /**
  * @brief Point d'entrée de l'application.
@@ -43,6 +44,11 @@ int main(int argc, char* argv[]) {
         SDL_Quit();
         return 1;
     }
+
+    // Demonstration of the AI integration
+    GameAI ai;
+    std::string response = ai.generateObject("Cr\xC3\xA9e un objet magique pour un jeu en C++");
+    std::cout << "GameAI: " << response << std::endl;
 
     int result = showMenu(window, renderer, width, height, targetFPS, language);
 


### PR DESCRIPTION
## Summary
- integrate TinyLlama through new `GameAI` helper
- hook Python script `ai_prompt.py` to run the GGUF model
- demonstrate usage from `main.cpp`
- document setup instructions for TinyLlama

## Testing
- `./scripts/build.sh` *(fails: FindSDL2.cmake not found)*

------
https://chatgpt.com/codex/tasks/task_e_6857302aed088321a95f6eef1e8a4b9e