### PR TITLE
Support PNG background without bundling asset

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -Wextra
-SDL_CFLAGS := $(shell pkg-config --cflags sdl2 SDL2_ttf)
-SDL_LIBS := $(shell pkg-config --libs sdl2 SDL2_ttf)
+SDL_CFLAGS := $(shell pkg-config --cflags sdl2 SDL2_ttf SDL2_image)
+SDL_LIBS := $(shell pkg-config --libs sdl2 SDL2_ttf SDL2_image)
 SRCS := $(wildcard src/*.cpp)
 OBJS := $(patsubst src/%.cpp, build/%.o, $(SRCS))
 TARGET := bin/arme_fatal

--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # jeuuuuu
 
-Simple SDL2/SDL2_ttf project example.
+Simple SDL2/SDL2_ttf/SDL2_image project example.
 
 ## Requirements
 
 - SDL2
 - SDL2_ttf
+- SDL2_image
 - Make
 
 ## Build
@@ -60,7 +61,8 @@ generate text using a local TinyLlama model.
 
 2. Place the `TinyLlama.Q4_0.gguf` model in the `models/` directory.
 
-For menu customization, add a BMP image at `assets/backgrounds/menu.bmp`.
+For menu customization, place your background image as `assets/backgrounds/menu.png`.
+If absent, the game falls back to `assets/backgrounds/menu.bmp`.
 
 The game calls the script at runtime to obtain generated text.
 

--- a/src/menu.cpp
+++ b/src/menu.cpp
@@ -1,6 +1,7 @@
 #include "menu.h"
 #include "jeu.h"
 #include "parametre.h"
+#include <SDL2/SDL_image.h>
 #include <SDL2/SDL_ttf.h>
 #include <iostream>
 #include <string>
@@ -50,19 +51,30 @@ int showMenu(SDL_Window* window, SDL_Renderer* renderer,
         return 1;
     }
 
+    int imgFlags = IMG_INIT_PNG;
+    bool pngInit = (IMG_Init(imgFlags) & imgFlags) != 0;
+    if (!pngInit) {
+        std::cerr << "Failed to init SDL_image: " << IMG_GetError() << std::endl;
+    }
+
     SDL_Texture* background = nullptr;
-    const std::string bgPath = "assets/backgrounds/menu.bmp";
-    if (SDL_Surface* surf = SDL_LoadBMP(bgPath.c_str())) {
+    const std::string pngPath = "assets/backgrounds/menu.png";
+    const std::string bmpPath = "assets/backgrounds/menu.bmp";
+    SDL_Surface* surf = nullptr;
+    if (pngInit)
+        surf = IMG_Load(pngPath.c_str());
+    if (!surf)
+        surf = SDL_LoadBMP(bmpPath.c_str());
+    if (surf) {
         background = SDL_CreateTextureFromSurface(renderer, surf);
         SDL_FreeSurface(surf);
         if (background) {
             std::cout << "Menu background loaded." << std::endl;
         } else {
-            std::cerr << "Failed to create background texture from " << bgPath
-                      << std::endl;
+            std::cerr << "Failed to create background texture from image" << std::endl;
         }
     } else {
-        std::cerr << "Failed to load background image: " << bgPath << std::endl;
+        std::cerr << "Failed to load background image" << std::endl;
     }
 
     std::vector<Button> buttons;
@@ -153,5 +165,7 @@ int showMenu(SDL_Window* window, SDL_Renderer* renderer,
     if (background)
         SDL_DestroyTexture(background);
     TTF_CloseFont(font);
+    if (pngInit)
+        IMG_Quit();
     return 0;
 }


### PR DESCRIPTION
## Summary
- clean up placeholder asset
- load PNG if SDL2_image is available and fall back to BMP using SDL_LoadBMP

## Testing
- `./scripts/lint.sh`
- `make` *(fails: SDL2, SDL2_ttf, SDL2_image not found)*

------
https://chatgpt.com/codex/tasks/task_e_68573ed7060083219646e501ad3da3d2