### PR TITLE
Add SDL icon support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX = g++
 CXXFLAGS = -std=c++17 -Wall -Wextra
-SDL_CFLAGS := $(shell pkg-config --cflags sdl2 SDL2_ttf)
-SDL_LIBS := $(shell pkg-config --libs sdl2 SDL2_ttf)
+SDL_CFLAGS := $(shell pkg-config --cflags sdl2 SDL2_ttf SDL2_image)
+SDL_LIBS := $(shell pkg-config --libs sdl2 SDL2_ttf SDL2_image)
 SRCS := $(wildcard src/*.cpp)
 OBJS := $(patsubst src/%.cpp, build/%.o, $(SRCS))
 TARGET := bin/arme_fatal

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,11 @@
+#include "GameAI.h"
+#include "menu.h"
 #include <SDL2/SDL.h>
+#include <SDL2/SDL_image.h>
 #include <SDL2/SDL_ttf.h>
 #include <filesystem>
 #include <iostream>
 #include <string>
-#include "menu.h"
-#include "GameAI.h"
 
 /**
  * @brief Point d'entrée de l'application.
@@ -23,6 +24,13 @@ int main(int argc, char* argv[]) {
         return 1;
     }
 
+    if (!(IMG_Init(IMG_INIT_PNG) & IMG_INIT_PNG)) {
+        std::cerr << "IMG_Init Error: " << IMG_GetError() << std::endl;
+        TTF_Quit();
+        SDL_Quit();
+        return 1;
+    }
+
     int width = 800;
     int height = 600;
     int targetFPS = 60;
@@ -33,8 +41,18 @@ int main(int argc, char* argv[]) {
     if (!window) {
         std::cerr << "SDL_CreateWindow Error: " << SDL_GetError() << std::endl;
         TTF_Quit();
+        IMG_Quit();
         SDL_Quit();
         return 1;
+    }
+
+    std::filesystem::path exePath = std::filesystem::absolute(argv[0]);
+    std::filesystem::path iconPath = (exePath.parent_path() / ".." / "assets" / "icon.png").lexically_normal();
+    if (SDL_Surface* icon = IMG_Load(iconPath.string().c_str())) {
+        SDL_SetWindowIcon(window, icon);
+        SDL_FreeSurface(icon);
+    } else {
+        std::cerr << "Failed to load icon: " << iconPath << " - " << IMG_GetError() << std::endl;
     }
 
     SDL_Renderer* renderer = SDL_CreateRenderer(window, -1, SDL_RENDERER_ACCELERATED);
@@ -47,10 +65,9 @@ int main(int argc, char* argv[]) {
     }
 
     // Demonstration of the AI integration
-    std::filesystem::path exePath = std::filesystem::absolute(argv[0]);
     std::filesystem::path scriptPath = (exePath.parent_path() / ".." / "scripts" /
-                                       "ai_prompt.py")
-                                          .lexically_normal();
+                                        "ai_prompt.py")
+                                           .lexically_normal();
     GameAI ai(scriptPath.string());
     std::string response = ai.generateObject("Cr\xC3\xA9e un objet magique pour un jeu en C++");
     std::cout << "GameAI: " << response << std::endl;
@@ -59,6 +76,7 @@ int main(int argc, char* argv[]) {
 
     SDL_DestroyRenderer(renderer);
     SDL_DestroyWindow(window);
+    IMG_Quit();
     TTF_Quit();
     SDL_Quit();
     return result;


### PR DESCRIPTION
## Summary
- allow loading PNG icon with SDL2_image
- link with SDL2_image in Makefile
- provide a small icon asset
- remove icon asset since the user will provide it

## Testing
- `make clean && make` *(fails: SDL2 missing)*
- `./scripts/lint.sh`

------
https://chatgpt.com/codex/tasks/task_e_68573f2325ec8321998032587e1285bf