### PR TITLE
Add console mining demo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,9 +2,12 @@ CXX = g++
 CXXFLAGS = -std=c++17 -Wall -Wextra
 SDL_CFLAGS := $(shell pkg-config --cflags sdl2 SDL2_ttf)
 SDL_LIBS := $(shell pkg-config --libs sdl2 SDL2_ttf)
-SRCS := $(wildcard src/*.cpp)
+MINER_SRCS := src/mine.cpp src/miner_main.cpp
+SRCS := $(filter-out $(MINER_SRCS), $(wildcard src/*.cpp))
 OBJS := $(patsubst src/%.cpp, build/%.o, $(SRCS))
+MINER_OBJS := $(patsubst src/%.cpp, build/%.o, $(MINER_SRCS))
 TARGET := bin/arme_fatal
+MINER_TARGET := bin/mine_game
 
 all: $(TARGET)
 
@@ -16,10 +19,16 @@ $(TARGET): $(OBJS)
 	@mkdir -p bin
 	$(CXX) $(OBJS) $(SDL_LIBS) -o $@
 
+$(MINER_TARGET): $(MINER_OBJS)
+	@mkdir -p bin
+	$(CXX) $(MINER_OBJS) -o $@
+
 clean:
-	rm -rf build $(TARGET)
+	rm -rf build $(TARGET) $(MINER_TARGET)
 
 run: $(TARGET)
 	$(TARGET)
 
-.PHONY: all clean run
+miner_run: $(MINER_TARGET)
+	$(MINER_TARGET)
+.PHONY: all clean run miner_run

--- a/include/Mine.h
+++ b/include/Mine.h
@@ -1,0 +1,59 @@
+#ifndef MINE_H
+#define MINE_H
+
+#include <iostream>
+#include <map>
+#include <string>
+
+#include "Random.h"
+
+// Enumeration of ores for future extension
+enum class TypeMinerai { Fer,
+                         Or,
+                         Argent };
+
+inline std::string toString(TypeMinerai type) {
+    switch (type) {
+    case TypeMinerai::Fer:
+        return "Fer";
+    case TypeMinerai::Or:
+        return "Or";
+    default:
+        return "Argent";
+    }
+}
+
+struct Outil {
+    std::string nom;
+    int durabilite{0};
+    int perteParExtraction{1};
+};
+
+class ZoneMinerai;
+
+class Joueur {
+    public:
+    explicit Joueur(Outil outil) : outilActif(std::move(outil)) {}
+    void extraire(ZoneMinerai& zone);
+    void afficherStatut() const;
+
+    std::map<std::string, int> ressources;
+    Outil outilActif;
+};
+
+class ZoneMinerai {
+    public:
+    ZoneMinerai(std::string n, TypeMinerai t, int diff, int stockInit)
+        : nom(std::move(n)), typeMinerai(t), difficulte(diff),
+          stockInitial(stockInit), stock(stockInit) {}
+
+    bool extraire(Joueur& joueur, int rng);
+
+    std::string nom;
+    TypeMinerai typeMinerai;
+    int difficulte;   // 1-100
+    int stockInitial; // initial quantity
+    int stock;        // remaining quantity
+};
+
+#endif // MINE_H

--- a/include/Random.h
+++ b/include/Random.h
@@ -1,0 +1,14 @@
+#ifndef RANDOM_H
+#define RANDOM_H
+
+#include <random>
+
+namespace Random {
+inline int range(int min, int max) {
+    static std::mt19937 rng(std::random_device{}());
+    std::uniform_int_distribution<int> dist(min, max);
+    return dist(rng);
+}
+} // namespace Random
+
+#endif // RANDOM_H

--- a/src/mine.cpp
+++ b/src/mine.cpp
@@ -1,0 +1,63 @@
+#include "Mine.h"
+#include <chrono>
+#include <thread>
+
+static void showProgress() {
+    const int barWidth = 20;
+    for (int i = 0; i < barWidth; ++i) {
+        std::cout << '\r' << '[' << std::string(i + 1, '#')
+                  << std::string(barWidth - i - 1, ' ') << ']';
+        std::cout.flush();
+        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    }
+    std::cout << std::endl;
+}
+
+void Joueur::extraire(ZoneMinerai& zone) {
+    if (outilActif.durabilite <= 0) {
+        std::cout << "Votre outil est cass\xC3\xA9 !\n";
+        return;
+    }
+    showProgress();
+    int rng = Random::range(1, 100);
+    bool reussite = zone.extraire(*this, rng);
+    if (reussite) {
+        outilActif.durabilite -= outilActif.perteParExtraction;
+        if (outilActif.durabilite <= 0) {
+            outilActif.durabilite = 0;
+            std::cout << "Votre outil s'est cass\xC3\xA9 !\n";
+        }
+    }
+}
+
+void Joueur::afficherStatut() const {
+    std::cout << "Outil: " << outilActif.nom
+              << " (durabilit\xC3\xA9: " << outilActif.durabilite << ")\n";
+    std::cout << "Inventaire:" << std::endl;
+    if (ressources.empty()) {
+        std::cout << "  (vide)\n";
+    }
+    for (const auto& p : ressources) {
+        std::cout << "  " << p.first << " x" << p.second << std::endl;
+    }
+}
+
+bool ZoneMinerai::extraire(Joueur& joueur, int rng) {
+    if (stock <= 0) {
+        std::cout << "La zone est \xC3\xA9puis\xC3\xA9e.\n";
+        return false;
+    }
+    int chance = 100 - difficulte;
+    if (rng <= chance) {
+        --stock;
+        joueur.ressources[toString(typeMinerai)]++;
+        std::cout << "Extraction r\xC3\xA9ussie !" << std::endl;
+        return true;
+    }
+    std::cout << "Extraction \xC3\xA9chou\xC3\xA9e." << std::endl;
+    return false;
+}
+
+// TODO: ajouter craft d'outils
+// TODO: sauvegarde fichier
+// TODO: tests unitaires

--- a/src/miner_main.cpp
+++ b/src/miner_main.cpp
@@ -1,0 +1,50 @@
+#include "Mine.h"
+#include <iostream>
+#include <vector>
+
+int main() {
+    Outil pioche{"Pioche rudimentaire", 5, 1};
+    Joueur joueur(pioche);
+    std::vector<ZoneMinerai> zones{
+        {"Carriere", TypeMinerai::Fer, 20, 5},
+        {"Mine ancienne", TypeMinerai::Or, 50, 3},
+        {"Grotte mysterieuse", TypeMinerai::Argent, 80, 2}};
+    ZoneMinerai* zoneCourante = &zones[0];
+
+    int choix = 0;
+    while (choix != 4) {
+        std::cout << "\n=== Menu Mine ===\n";
+        std::cout << "Zone actuelle: " << zoneCourante->nom << "\n";
+        std::cout << "[1] Choisir zone\n";
+        std::cout << "[2] Examiner inventaire / outil\n";
+        std::cout << "[3] Extraire dans zone courante\n";
+        std::cout << "[4] Quitter\n";
+        std::cout << "Choix: ";
+        std::cin >> choix;
+        switch (choix) {
+        case 1: {
+            for (size_t i = 0; i < zones.size(); ++i) {
+                std::cout << i + 1 << ". " << zones[i].nom
+                          << " (stock: " << zones[i].stock << ")\n";
+            }
+            size_t zi = 0;
+            std::cin >> zi;
+            if (zi >= 1 && zi <= zones.size())
+                zoneCourante = &zones[zi - 1];
+            break;
+        }
+        case 2:
+            joueur.afficherStatut();
+            break;
+        case 3:
+            joueur.extraire(*zoneCourante);
+            break;
+        case 4:
+            std::cout << "Au revoir !\n";
+            break;
+        default:
+            std::cout << "Choix invalide." << std::endl;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add console-based mining mini-game
- support random number generation helper
- extend Makefile with new target `mine_game`

## Testing
- `make` *(fails: SDL2 missing)*
- `make bin/mine_game`

------
https://chatgpt.com/codex/tasks/task_e_68573e6b186c8321b04b711b248520e7